### PR TITLE
Make retry on pngquant status 99 an optional behavior

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,6 +177,15 @@ module.exports = function(grunt) {
         },
         src: 'test/fixtures/haustest.png',
         dest: 'tmp/quality_test/'
+      },
+      quality_test5: {
+        options: {
+          ext: '-qual5.png',
+          quality: '65-80',
+          retry: false
+        },
+        src: 'test/fixtures/haustest.png',
+        dest: 'tmp/quality_test/'
       }
     },
 
@@ -209,7 +218,8 @@ module.exports = function(grunt) {
     'pngmin:quality_test',
     'pngmin:quality_test2',
     'pngmin:quality_test3',
-    'pngmin:quality_test4'
+    'pngmin:quality_test4',
+    'pngmin:quality_test5'
   ]);
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Default value: `'pngquant'` in your `PATH` or `'bin/pngquant'`
 This option is just for users where the pngquant-bin package could not be installed correctly. Normally you don't need this!
 The pngquant executable which will be spawned. If the pngquant binary is not found in `PATH` the default fallback is `'bin/pngquant'`, but this option has always precedence.
 
+#### options.retry
+Type: `Boolean`
+Default value: `false`
+
+If pngquant exits with status 99 (ie it was not able to compress with the specified quality option), allow pngmin to try again without quality option.
+
 ### Usage Examples
 
 #### Default Options

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The pngquant executable which will be spawned. If the pngquant binary is not fou
 
 #### options.retry
 Type: `Boolean`
-Default value: `false`
+Default value: `true`
 
 If pngquant exits with status 99 (ie it was not able to compress with the specified quality option), allow pngmin to try again without quality option.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-pngmin",
   "description": "Grunt plugin to compress png images with pngquant.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/zauni/pngmin",
   "author": {
     "name": "Matthias Zaunseder",

--- a/tasks/pngmin.js
+++ b/tasks/pngmin.js
@@ -82,7 +82,7 @@ module.exports = function(grunt) {
             args.push('--ext=.png', '--force', '--speed=' + options.speed, '--', tmpDest);
 
             var cb = function(error, result, code) {
-                if(error && code === 99 && tries === 1) {
+                if(options.retry && error && code === 99 && tries === 1) {
                     args = _.filter(args, function(arg) {
                         if(_.isString(arg) && arg.indexOf('--quality') === 0) {
                             return false;
@@ -159,7 +159,8 @@ module.exports = function(grunt) {
             quality: null,
             force: false,
             speed: 3,
-            iebug: false
+            iebug: false,
+            retry: false
         });
 
         // reset

--- a/tasks/pngmin.js
+++ b/tasks/pngmin.js
@@ -160,7 +160,7 @@ module.exports = function(grunt) {
             force: false,
             speed: 3,
             iebug: false,
-            retry: false
+            retry: true
         });
 
         // reset

--- a/test/pngmin_test.js
+++ b/test/pngmin_test.js
@@ -123,7 +123,7 @@ exports.pngmin = {
     test.done();
   },
   quality_test: function(test) {
-    test.expect(2);
+    test.expect(3);
 
     var actual = grunt.file.read('tmp/quality_test/pngquant-logo-qual2.png');
     var already_optimized = grunt.file.read('tmp/pngquant-logo-fs8.png');
@@ -131,8 +131,9 @@ exports.pngmin = {
 
     var qualityError = grunt.file.read('tmp/quality_test/haustest-qual4.png');
     var notOptimized = grunt.file.read('test/fixtures/haustest.png');
-
     test.ok(qualityError.length < notOptimized.length, 'after an error with quality option, it should be optimized without quality option!');
+
+    test.ok(!grunt.file.exists('tmp/quality_test/haustest-qual5.png'), 'after an error with quality option, if options.retry is set to false, it should not be optimized without quality option!');
 
     test.done();
   }


### PR DESCRIPTION
I'm using pngmin in a project and I have an issue with the retry behavior of the module (see https://github.com/zauni/pngmin/commit/6b21e9db1f0b8cbf0438727d9b15d25309983372). When the quality option cannot be met, pngmin retries ignoring the quality option and compress the image anyway, and I end up with a lower-than-expected quality.

I feel this is not a good behavior. Indeed, if I specify a quality parameter, I expect grunt-pngmin to honor this parameter. That is how pngquant works: if the quality option cannot be met, pngquant does not produce a result.

As of now, I cannot set a minimum quality for my images confidently because pngmin may override it.

So here is a pull request to make the retry behavior optional so that the quality parameter is always honored.